### PR TITLE
Add Envelope to Fix Audio Click and Popping Sound

### DIFF
--- a/main.js
+++ b/main.js
@@ -128,7 +128,10 @@ function presskey(kp) {
                 speed *= 1;
             }
             if (gamemode[1].checked) {
-                speed *= 1.01;
+                if (speed < 120)
+                    speed *= 1.01;
+                else 
+                    speed *= 1.001;
             }
             if (gamemode[2].checked) {
                 speed *= 1.03;
@@ -148,8 +151,6 @@ function opensettings() {
     appstart.style.display = "flex";
 }
 
-window.AudioContext = window.AudioContext || window.webkitAudioContext;
-var context = new AudioContext();
 function playSound() {
     if (!isSoundMuted) {
         arr = notes[(score - 1) % tones.length];
@@ -169,16 +170,42 @@ function sineWaveAt(sampleNumber, tone) {
     return Math.sin(sampleNumber / (sampleFreq / (Math.PI * 2)))
 }
 
+function linearEnvelope(endOfFadeIn, startOfFadeOut, samples) {
+    var envelope = new Array(samples).fill(1);
+    for (var i = 0; i < samples; i++)
+    {
+        if (i < endOfFadeIn)
+            envelope[i] = i;
+        else if (i < startOfFadeOut) 
+            envelope[i] = envelope[i-1];
+        else 
+            envelope[i] = envelope[i-1]-1;   
+    }
+    return envelope
+}
+
+window.AudioContext = window.AudioContext || window.webkitAudioContext;
+var context = new AudioContext();
 
 var notes = [];
 var volume = 0.5;
 var seconds = 0.2;
 var tones = [392.00, 311.13, 293.66, 261.63, 261.63, 293.66, 311.13, 261.63, 311.13, 392.00, 415.30, 392.00, 349.23, 349.23, 293.66, 261.63, 246.94, 196.00, 246.94, 293.66, 246.94, 293.66, 349.23, 392.00, 415.30, 369.99, 392.00];
 
+// Load in notes 
 for (var t = 0; t < tones.length; t++) {
     var arr = [];
-    for (var i = 0; i < context.sampleRate * seconds; i++) {
-        arr[i] = sineWaveAt(i, tones[t]) * volume;
+    var samples = context.sampleRate * seconds;
+    endOfFadeIn = samples / 4;
+    startOfFadeOut = samples * 3 / 4;
+
+    envelope = getEnvelope(startOfFadeIn, startOfFadeOut, samples);
+    envelopeMax = Math.max.apply(null, envelope)
+
+    for (var i = 0; i < samples; i++) {
+        arr[i] = sineWaveAt(i, tones[t]) * envelope[i]/envelopeMax/2;
     }
+
+    console.log(notes);
     notes.push(arr);
 }

--- a/main.js
+++ b/main.js
@@ -186,7 +186,7 @@ var context = new AudioContext();
 
 var notes = [];
 var volume = 0.5;
-var seconds = 0.2;
+var seconds = 0.3;
 var tones = [392.00, 311.13, 293.66, 261.63, 261.63, 293.66, 311.13, 261.63, 311.13, 392.00, 415.30, 392.00, 349.23, 349.23, 293.66, 261.63, 246.94, 196.00, 246.94, 293.66, 246.94, 293.66, 349.23, 392.00, 415.30, 369.99, 392.00];
 
 // Load in notes 
@@ -196,13 +196,11 @@ for (var t = 0; t < tones.length; t++) {
     endOfFadeIn = samples / 4;
     startOfFadeOut = samples * 3 / 4;
 
-    envelope = linearEnvelope(startOfFadeIn, startOfFadeOut, samples);
+    let envelope = linearEnvelope(endOfFadeIn, startOfFadeOut, samples);
     envelopeMax = Math.max.apply(null, envelope)
 
     for (var i = 0; i < samples; i++) {
         arr[i] = sineWaveAt(i, tones[t]) * envelope[i]/envelopeMax/2;
     }
-
-    console.log(notes);
     notes.push(arr);
 }

--- a/main.js
+++ b/main.js
@@ -128,7 +128,7 @@ function presskey(kp) {
                 speed *= 1;
             }
             if (gamemode[1].checked) {
-                    speed *= 1.01;
+                speed *= 1.01;
             }
             if (gamemode[2].checked) {
                 speed *= 1.03;

--- a/main.js
+++ b/main.js
@@ -128,10 +128,7 @@ function presskey(kp) {
                 speed *= 1;
             }
             if (gamemode[1].checked) {
-                if (speed < 120)
                     speed *= 1.01;
-                else 
-                    speed *= 1.001;
             }
             if (gamemode[2].checked) {
                 speed *= 1.03;
@@ -199,7 +196,7 @@ for (var t = 0; t < tones.length; t++) {
     endOfFadeIn = samples / 4;
     startOfFadeOut = samples * 3 / 4;
 
-    envelope = getEnvelope(startOfFadeIn, startOfFadeOut, samples);
+    envelope = linearEnvelope(startOfFadeIn, startOfFadeOut, samples);
     envelopeMax = Math.max.apply(null, envelope)
 
     for (var i = 0; i < samples; i++) {


### PR DESCRIPTION
Hey! I saw this project in the comments section of HackerNews and was really impressed by it. I spent a decent chunk of time playing and practicing using it.

One issue I had was that the audio was giving some popping or crackling sounds. Ultimately not a major issue, but I figured it should be fixable. Though, It was also more of a learning experience than I expected! After some analysis I figure that the problem seems to be that the audio frequency changes abruptly when you use a rectangular window for each tone. Adding a linear 'envelope' to each note seems to make the problem disappear for me.

I plotted some varying frequency pulses in python to visualize these transitions:
# Before
![image](https://github.com/qwertytiles/qwertytiles.github.io/assets/56418392/635fbcf7-8c58-4dba-98aa-b1b7dbc8f12d)

In the original audio signal, there's a stark and unnatural transition from the "on" to "off" states. This sharp change is likely what caused the popping sounds. 

# After
![image](https://github.com/qwertytiles/qwertytiles.github.io/assets/56418392/d8c9d66f-d828-451e-927c-c9f8a7451777)
Now, adding some 'attack' and 'decay' to shape the pulses, the changes are less abrupt and so it sounds more natural.

I'm still curious on how to best use these in practice, but the simple linear envelope works for me, and I no longer hear the popping sounds from before.

I'd love to also hear any suggestions or thoughts you might have.

Thanks for the cool game BTW!